### PR TITLE
Run build on ubuntu-latest only

### DIFF
--- a/.github/workflows/build-docs-verifier.yml
+++ b/.github/workflows/build-docs-verifier.yml
@@ -9,9 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         configuration: [debug, release]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
I think it may be noisy to run it on all OSes. Since we usually run the action in linux environment, I believe it should be good enough to build only for Linux in CI.