### PR TITLE
Fix dogfood failure

### DIFF
--- a/actions/docs-verifier/valid-test-cases/MSDocsSpecific/Includes/aspnetcore.md
+++ b/actions/docs-verifier/valid-test-cases/MSDocsSpecific/Includes/aspnetcore.md
@@ -2,4 +2,4 @@ The following breaking changes in ASP.NET Core 3.0 and 3.1 are documented on thi
 - [Obsolete Antiforgery, CORS, Diagnostics, MVC, and Routing APIs removed](#obsolete-antiforgery-cors-diagnostics-mvc-and-routing-apis-removed)
 
 
-[!INCLUDE[Obsolete Antiforgery, CORS, Diagnostics, MVC, and Routing APIs removed](~/valid-test-cases/MSDocsSpecific/Includes/include.md)]
+[!INCLUDE[Obsolete Antiforgery, CORS, Diagnostics, MVC, and Routing APIs removed](~/actions/docs-verifier/valid-test-cases/MSDocsSpecific/Includes/include.md)]

--- a/actions/docs-verifier/valid-test-cases/MarkdownLinksVerifier/test1/File1.md
+++ b/actions/docs-verifier/valid-test-cases/MarkdownLinksVerifier/test1/File1.md
@@ -1,6 +1,6 @@
 [text](File1.md)
 [text](./File1.md)
-[text](/valid-test-cases/MarkdownLinksVerifier/test1/File1.md)
+[text](/actions/docs-verifier/valid-test-cases/MarkdownLinksVerifier/test1/File1.md)
 [text](folder/Name%20With%20Space.md)
 [text](folder)
 [text](./folder)


### PR DESCRIPTION
Issue here is that when I moved the code from my repo, the `valid-tests` folder used to be in root. Now since it's not in root, these links were indeed dead.