### PR TITLE
Dont fail on extension change only

### DIFF
--- a/actions/docs-verifier/.editorconfig
+++ b/actions/docs-verifier/.editorconfig
@@ -23,9 +23,6 @@ dotnet_diagnostic.CA2007.severity = none
 # IDE0044: Add readonly modifier
 dotnet_style_readonly_field = true
 
-# Default severity for analyzer diagnostics with category 'Style'
-dotnet_analyzer_diagnostic.category-Style.severity = warning
-
 # IDE0022: Use block body for methods
 dotnet_diagnostic.IDE0022.severity = silent
 csharp_style_expression_bodied_methods = when_on_single_line

--- a/actions/docs-verifier/src/ActionRunner/Program.cs
+++ b/actions/docs-verifier/src/ActionRunner/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using GitHub;
 using MarkdownLinksVerifier;
@@ -40,28 +41,22 @@ foreach (PullRequestFile file in files)
         }
     }
 
-    static bool IsExtensionChangeOnly(string file1, string file2)
-    {
-        return TryStripYmlOrMarkdownExtension(file1, out string strippedFile1) &&
-            TryStripYmlOrMarkdownExtension(file2, out string strippedFile2) &&
-            strippedFile1.Equals(strippedFile2, StringComparison.OrdinalIgnoreCase);
-    }
+    static bool IsExtensionChangeOnly(string file1, string file2) =>
+        TryStripYmlOrMarkdownExtension(file1, out string strippedFile1) &&
+        TryStripYmlOrMarkdownExtension(file2, out string strippedFile2) &&
+        strippedFile1.Equals(strippedFile2, StringComparison.OrdinalIgnoreCase);
 
     static bool TryStripYmlOrMarkdownExtension(string file, out string strippedFile)
     {
-        if (file.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
+        (string subFile, bool result) = Path.GetExtension(file) switch
         {
-            strippedFile = file.Substring(0, file.Length - ".yml".Length);
-            return true;
-        }
-        else if (file.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
-        {
-            strippedFile = file.Substring(0, file.Length - ".md".Length);
-            return true;
-        }
+            string ext when ext is ".yml" or ".md" =>
+                (file.Substring(0, file.Length - ext.Length), true),
+            _ => (file, false)
+        };
 
-        strippedFile = file;
-        return false;
+        strippedFile = subFile;
+        return result;
     }
 }
 

--- a/actions/docs-verifier/src/GitHub/PullRequestFileExtensions.cs
+++ b/actions/docs-verifier/src/GitHub/PullRequestFileExtensions.cs
@@ -9,10 +9,19 @@ namespace GitHub
         private const string FILE_RENAMED_STATUS = "renamed";
         private const string FILE_REMOVED_STATUS = "removed";
 
+        /// <remarks>
+        /// An added file has a non-null <see cref="PullRequestFile.PreviousFileName"/> and <see cref="PullRequestFile.FileName"/>
+        /// </remarks>
         public static bool IsRenamed(this PullRequestFile file) => file?.Status == FILE_RENAMED_STATUS;
 
+        /// <remarks>
+        /// An added file has a null <see cref="PullRequestFile.PreviousFileName"/>
+        /// </remarks>
         public static bool IsAdded(this PullRequestFile file) => file?.Status == FILE_ADDED_STATUS;
 
+        /// <remarks>
+        /// An added file has a null <see cref="PullRequestFile.PreviousFileName"/>
+        /// </remarks>
         public static bool IsRemoved(this PullRequestFile file) => file?.Status == FILE_REMOVED_STATUS;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs-actions/issues/12

~~Hard to confirm the correctness of the change without running against an actual PR. Consider creating a new branch, merge the PR to it, and try the change in dotnet/docs before this gets merged into main. So if this change has any bugs/issues, it doesn't affect PRs coming to dotnet/docs.~~ No need to do that. It was easy to confirm on my fork of dotnet/docs.