### PR TITLE
on: pull_request

### DIFF
--- a/.github/workflows/build-docs-verifier.yml
+++ b/.github/workflows/build-docs-verifier.yml
@@ -1,7 +1,5 @@
 name: Build docs-verifier
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
The usage of `pull_request_target` causes checkout to be done against the current `main`, not the PR branch. This can cause issues to be discovered late (as you can see with the build failing now). I'll be fixing the build in another PR, this needs to be merged first for the other PR to pass cleanly.