### PR TITLE
Add two new `abstract` base classes for reading / caching JSON config files

### DIFF
--- a/actions/docs-verifier/BuildVerifier.IO.Abstractions/BaseConfigurationReader.cs
+++ b/actions/docs-verifier/BuildVerifier.IO.Abstractions/BaseConfigurationReader.cs
@@ -56,21 +56,5 @@ namespace BuildVerifier.IO.Abstractions
 
             return s_cachedConfiguration;
         }
-
-        /// <summary>
-        /// (Optionally) maps the configuration file into a custom result object.
-        /// If not overridden in a subclass, returns the cached <typeparamref name="TConfigurationFile"/> file.
-        /// </summary>
-        public virtual async ValueTask<TResult?> MapConfigurationAsync<TResult>()
-            where TResult : class
-        {
-            TConfigurationFile? configuration = await ReadConfigurationAsync();
-            if (configuration is not null)
-            {
-                return configuration as TResult;
-            }
-            
-            return default;
-        }
     }
 }

--- a/actions/docs-verifier/BuildVerifier.IO.Abstractions/BaseConfigurationReader.cs
+++ b/actions/docs-verifier/BuildVerifier.IO.Abstractions/BaseConfigurationReader.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace BuildVerifier.IO.Abstractions
+{
+    public abstract class BaseConfigurationReader<TConfigurationFile>
+        where TConfigurationFile : class
+    {
+        private static readonly JsonSerializerOptions s_options = new()
+        {
+            AllowTrailingCommas = true
+        };
+
+        private TConfigurationFile? s_cachedConfiguration;
+        private bool? s_fileExists;
+
+        /// <summary>
+        /// The name of the configuration file on disk.
+        /// The name is used relatively with <see cref="File.Exists(string)"/>.
+        /// </summary>
+        public abstract string ConfigurationFileName { get; }
+
+        /// <summary>
+        /// Reads (or returns the cached) <typeparamref name="TConfigurationFile"/> file.
+        /// </summary>
+        public async ValueTask<TConfigurationFile?> ReadConfigurationAsync()
+        {
+            // Only check if the file exists one time.
+            if (s_fileExists is null)
+            {
+                s_fileExists = File.Exists(ConfigurationFileName);
+            }
+
+            // If there are cached configuration values, use 'em.
+            if (s_cachedConfiguration is not null)
+            {
+                return s_cachedConfiguration;
+            }
+
+            if (s_fileExists.Value)
+            {
+                string json = await File.ReadAllTextAsync(ConfigurationFileName);
+
+                TConfigurationFile? configuration =
+                    JsonSerializer.Deserialize<TConfigurationFile>(json, s_options);
+
+                if (configuration is null)
+                {
+                    throw new InvalidOperationException($"Failed to read '{ConfigurationFileName}'.");
+                }
+
+                s_cachedConfiguration = configuration;
+            }
+
+            return s_cachedConfiguration;
+        }
+
+        /// <summary>
+        /// (Optionally) maps the configuration file into a custom result object.
+        /// If not overridden in a subclass, returns the cached <typeparamref name="TConfigurationFile"/> file.
+        /// </summary>
+        public virtual async ValueTask<TResult?> MapConfigurationAsync<TResult>()
+            where TResult : class
+        {
+            TConfigurationFile? configuration = await ReadConfigurationAsync();
+            if (configuration is not null)
+            {
+                return configuration as TResult;
+            }
+            
+            return default;
+        }
+    }
+}

--- a/actions/docs-verifier/BuildVerifier.IO.Abstractions/BaseMappedConfigurationReader.cs
+++ b/actions/docs-verifier/BuildVerifier.IO.Abstractions/BaseMappedConfigurationReader.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace BuildVerifier.IO.Abstractions
+{
+    public abstract class BaseMappedConfigurationReader<TConfigurationFile, TMappedResult>
+        : BaseConfigurationReader<TConfigurationFile>
+        where TConfigurationFile : class
+    {
+        public abstract ValueTask<TMappedResult> MapConfigurationAsync();
+    }
+}

--- a/actions/docs-verifier/BuildVerifier.IO.Abstractions/BaseMappedConfigurationReader.cs
+++ b/actions/docs-verifier/BuildVerifier.IO.Abstractions/BaseMappedConfigurationReader.cs
@@ -6,6 +6,9 @@ namespace BuildVerifier.IO.Abstractions
         : BaseConfigurationReader<TConfigurationFile>
         where TConfigurationFile : class
     {
+        /// <summary>
+        /// Maps the <typeparamref name="TConfigurationFile"/> into a consumer-defined <typeparamref name="TMappedResult"/>.
+        /// </summary>
         public abstract ValueTask<TMappedResult> MapConfigurationAsync();
     }
 }

--- a/actions/docs-verifier/BuildVerifier.IO.Abstractions/BuildVerifier.IO.Abstractions.csproj
+++ b/actions/docs-verifier/BuildVerifier.IO.Abstractions/BuildVerifier.IO.Abstractions.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/actions/docs-verifier/BuildVerifier.IO.Abstractions/BuildVerifier.IO.Abstractions.csproj
+++ b/actions/docs-verifier/BuildVerifier.IO.Abstractions/BuildVerifier.IO.Abstractions.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/actions/docs-verifier/BuildVerifier.IO.Abstractions/BuildVerifier.IO.Abstractions.csproj
+++ b/actions/docs-verifier/BuildVerifier.IO.Abstractions/BuildVerifier.IO.Abstractions.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
-  </ItemGroup>
 
 </Project>

--- a/actions/docs-verifier/MSDocsBuildVerifier.sln
+++ b/actions/docs-verifier/MSDocsBuildVerifier.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31025.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31410.414
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FB9E2FB6-DF28-4985-87D6-0334B8260365}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,12 +15,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MarkdownLinksVerifier.UnitT
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MarkdownLinksVerifier", "src\MarkdownLinksVerifier\MarkdownLinksVerifier.csproj", "{AB7C85DF-B59E-44D0-BC02-56353818C2EB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHub", "src\GitHub\GitHub.csproj", "{70FE70B7-E2D4-4C40-BD0B-D5ED8DBC69B4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitHub", "src\GitHub\GitHub.csproj", "{70FE70B7-E2D4-4C40-BD0B-D5ED8DBC69B4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedirectionVerifier", "src\RedirectionVerifier\RedirectionVerifier.csproj", "{4D897639-E46D-43DE-BB72-68D598F53EFB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RedirectionVerifier", "src\RedirectionVerifier\RedirectionVerifier.csproj", "{4D897639-E46D-43DE-BB72-68D598F53EFB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHub.UnitTests", "tests\GitHub.UnitTests\GitHub.UnitTests.csproj", "{1E5C7AB5-75A5-419A-97FC-6ED0CAB4CF90}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActionRunner", "src\ActionRunner\ActionRunner.csproj", "{097626C4-F50D-4183-AB2F-9EBAA49E960C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitHub.UnitTests", "tests\GitHub.UnitTests\GitHub.UnitTests.csproj", "{1E5C7AB5-75A5-419A-97FC-6ED0CAB4CF90}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ActionRunner", "src\ActionRunner\ActionRunner.csproj", "{097626C4-F50D-4183-AB2F-9EBAA49E960C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuildVerifier.IO.Abstractions", "BuildVerifier.IO.Abstractions\BuildVerifier.IO.Abstractions.csproj", "{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -104,6 +107,18 @@ Global
 		{097626C4-F50D-4183-AB2F-9EBAA49E960C}.Release|x64.Build.0 = Release|Any CPU
 		{097626C4-F50D-4183-AB2F-9EBAA49E960C}.Release|x86.ActiveCfg = Release|Any CPU
 		{097626C4-F50D-4183-AB2F-9EBAA49E960C}.Release|x86.Build.0 = Release|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Debug|x64.Build.0 = Debug|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Debug|x86.Build.0 = Debug|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Release|x64.ActiveCfg = Release|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Release|x64.Build.0 = Release|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Release|x86.ActiveCfg = Release|Any CPU
+		{FD67DE5D-D8C0-48AD-A7F9-E6F316821E10}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/actions/docs-verifier/MSDocsBuildVerifier.sln
+++ b/actions/docs-verifier/MSDocsBuildVerifier.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31410.414
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31025.194
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FB9E2FB6-DF28-4985-87D6-0334B8260365}"
 	ProjectSection(SolutionItems) = preProject

--- a/actions/docs-verifier/src/ActionRunner/Program.cs
+++ b/actions/docs-verifier/src/ActionRunner/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using GitHub;
@@ -70,13 +71,15 @@ static bool IsRedirectableFile(
 
     // A deleted toc.yml doesn't need redirection.
     // Also, don't require a redirection for file patterns specified as "exclude"s in docfx config file.
-    return !isDeletedToc && IsYmlOrMarkdownFile(deletedFileName) && !IsInWhatsNewDirectory(deletedFileName, whatsNewPath) &&
+    return !isDeletedToc && IsYmlOrMarkdownFile(deletedFileName)
+        && !IsInWhatsNewDirectory(deletedFileName, whatsNewPath) &&
         matchers.Any(m => m.Match(deletedFileName).HasMatches);
 }
 
-static bool IsYmlOrMarkdownFile(string? fileName) => Path.GetExtension(fileName) is ".yml" or ".md";
+static bool IsYmlOrMarkdownFile([NotNullWhen(true)] string? fileName) =>
+    Path.GetExtension(fileName) is ".yml" or ".md";
 
-static bool IsInWhatsNewDirectory(string? fileName, string? whatsNewPath)
+static bool IsInWhatsNewDirectory(string fileName, string? whatsNewPath)
 {
     if (whatsNewPath is { Length: > 0 })
     {
@@ -84,7 +87,7 @@ static bool IsInWhatsNewDirectory(string? fileName, string? whatsNewPath)
         // file.FileName:   docs/whats-new/2021-03.md
         // whatsNewPath:    docs/whats-new
 
-        return fileName?.StartsWith(whatsNewPath, StringComparison.OrdinalIgnoreCase) == true;
+        return fileName.StartsWith(whatsNewPath, StringComparison.OrdinalIgnoreCase);
     }
 
     return false;

--- a/actions/docs-verifier/src/ActionRunner/Program.cs
+++ b/actions/docs-verifier/src/ActionRunner/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using GitHub;
@@ -9,7 +10,8 @@ using Microsoft.Extensions.FileSystemGlobbing;
 using Octokit;
 using RedirectionVerifier;
 
-MarkdownLinksVerifierConfiguration configuration = await ConfigurationReader.GetConfigurationAsync();
+ConfigurationReader configurationReader = new();
+MarkdownLinksVerifierConfiguration? configuration = await configurationReader.ReadConfigurationAsync();
 int returnCode = await MarkdownFilesAnalyzer.WriteResultsAsync(Console.Out, configuration);
 
 // on: pull_request
@@ -20,7 +22,18 @@ if (!int.TryParse(Environment.GetEnvironmentVariable("GITHUB_PR_NUMBER"), out in
     throw new InvalidOperationException($"The value of GITHUB_PR_NUMBER environment variable is not valid.");
 }
 
-List<PullRequestFile> files = (await GitHubPullRequest.GetPullRequestFilesAsync(pullRequestNumber)).Where(f => IsRedirectableFile(f)).ToList();
+DocfxConfigurationReader docfxConfigurationReader = new();
+IEnumerable<Matcher> matchers = await docfxConfigurationReader.MapConfigurationAsync();
+IEnumerable<PullRequestFile> pullRequestFiles = await GitHubPullRequest.GetPullRequestFilesAsync(pullRequestNumber);
+
+WhatsNewConfigurationReader whatsNewConfigurationReader = new();
+string? whatsNewPath = await whatsNewConfigurationReader.MapConfigurationAsync();
+
+OpenPublishingRedirectionReader redirectionReader = new();
+ImmutableArray<Redirection> redirections = await redirectionReader.MapConfigurationAsync();
+
+List<PullRequestFile> files =
+    pullRequestFiles.Where(f => IsRedirectableFile(f, matchers, whatsNewPath)).ToList();
 
 // We should only ever fail on MD and YML files, no other files require redirection.
 // Also, filter out files that are part of the "What's new" directory - as they shouldn't require redirects.
@@ -30,14 +43,14 @@ foreach (PullRequestFile file in files)
     // In both cases, the URL in live docs site is the same.
     if (file.IsRenamed() && !IsExtensionChangeOnly(file.PreviousFileName, file.FileName))
     {
-        if (!await RedirectionsVerifier.WriteResultsAsync(Console.Out, file.PreviousFileName))
+        if (!await RedirectionsVerifier.WriteResultsAsync(Console.Out, file.PreviousFileName, redirections))
         {
             returnCode++;
         }
     }
     else if (file.IsRemoved() && !files.Any(f => f.IsAdded() && IsExtensionChangeOnly(file.FileName, f.FileName)))
     {
-        if (!await RedirectionsVerifier.WriteResultsAsync(Console.Out, file.FileName))
+        if (!await RedirectionsVerifier.WriteResultsAsync(Console.Out, file.FileName, redirections))
         {
             returnCode++;
         }
@@ -46,7 +59,8 @@ foreach (PullRequestFile file in files)
 
 return returnCode;
 
-static bool IsRedirectableFile(PullRequestFile file)
+static bool IsRedirectableFile(
+    PullRequestFile file, IEnumerable<Matcher> matchers, string? whatsNewPath)
 {
     string? deletedFileName = file.IsRenamed()
         ? file.PreviousFileName
@@ -56,15 +70,14 @@ static bool IsRedirectableFile(PullRequestFile file)
 
     // A deleted toc.yml doesn't need redirection.
     // Also, don't require a redirection for file patterns specified as "exclude"s in docfx config file.
-    return !isDeletedToc && IsYmlOrMarkdownFile(deletedFileName) && !IsInWhatsNewDirectory(deletedFileName) &&
-        DocfxConfigurationReader.GetMatchers().Any(m => m.Match(deletedFileName).HasMatches);
+    return !isDeletedToc && IsYmlOrMarkdownFile(deletedFileName) && !IsInWhatsNewDirectory(deletedFileName, whatsNewPath) &&
+        matchers.Any(m => m.Match(deletedFileName).HasMatches);
 }
 
 static bool IsYmlOrMarkdownFile(string? fileName) => Path.GetExtension(fileName) is ".yml" or ".md";
 
-static bool IsInWhatsNewDirectory(string? fileName)
+static bool IsInWhatsNewDirectory(string? fileName, string? whatsNewPath)
 {
-    string? whatsNewPath = WhatsNewConfigurationReader.GetWhatsNewPath();
     if (whatsNewPath is { Length: > 0 })
     {
         // Example:

--- a/actions/docs-verifier/src/MarkdownLinksVerifier/Configuration/ConfigurationReader.cs
+++ b/actions/docs-verifier/src/MarkdownLinksVerifier/Configuration/ConfigurationReader.cs
@@ -1,30 +1,9 @@
-﻿using System;
-using System.IO;
-using System.Text.Json;
-using System.Threading.Tasks;
+﻿using BuildVerifier.IO.Abstractions;
 
 namespace MarkdownLinksVerifier.Configuration
 {
-    public static class ConfigurationReader
+    public class ConfigurationReader : BaseConfigurationReader<MarkdownLinksVerifierConfiguration>
     {
-        private static readonly JsonSerializerOptions s_options = new() { AllowTrailingCommas = true };
-        internal const string ConfigurationFileName = "markdown-links-verifier-config.json";
-
-        public static async Task<MarkdownLinksVerifierConfiguration> GetConfigurationAsync()
-        {
-            if (!File.Exists(ConfigurationFileName))
-            {
-                return MarkdownLinksVerifierConfiguration.Empty;
-            }
-
-            string json = await File.ReadAllTextAsync(ConfigurationFileName);
-            MarkdownLinksVerifierConfiguration? config = JsonSerializer.Deserialize<MarkdownLinksVerifierConfiguration>(json, s_options);
-            if (config is null)
-            {
-                throw new InvalidOperationException($"Failed to read '{ConfigurationFileName}'.");
-            }
-
-            return config;
-        }
+        public override string ConfigurationFileName => "markdown-links-verifier-config.json";
     }
 }

--- a/actions/docs-verifier/src/MarkdownLinksVerifier/Configuration/MarkdownLinksVerifierConfiguration.cs
+++ b/actions/docs-verifier/src/MarkdownLinksVerifier/Configuration/MarkdownLinksVerifierConfiguration.cs
@@ -6,13 +6,10 @@ using System.Text.Json.Serialization;
 namespace MarkdownLinksVerifier.Configuration
 {
     public record MarkdownLinksVerifierConfiguration(
-        [property: JsonPropertyName("excludeStartingWith")]
-        ImmutableArray<string> ExcludeStartingWith
-        )
+        [property: JsonPropertyName("excludeStartingWith")] ImmutableArray<string> ExcludeStartingWith)
     {
-        public static readonly MarkdownLinksVerifierConfiguration Empty = new(default(ImmutableArray<string>));
-
         public bool IsLinkExcluded(string link)
-            => !ExcludeStartingWith.IsDefaultOrEmpty && ExcludeStartingWith.Any(excludedPrefix => link.StartsWith(excludedPrefix, StringComparison.Ordinal));
+            => !ExcludeStartingWith.IsDefaultOrEmpty
+            && ExcludeStartingWith.Any(excludedPrefix => link.StartsWith(excludedPrefix, StringComparison.Ordinal));
     }
 }

--- a/actions/docs-verifier/src/MarkdownLinksVerifier/MarkdownFilesAnalyzer.cs
+++ b/actions/docs-verifier/src/MarkdownLinksVerifier/MarkdownFilesAnalyzer.cs
@@ -12,7 +12,7 @@ namespace MarkdownLinksVerifier
 {
     public static class MarkdownFilesAnalyzer
     {
-        public static async Task<int> WriteResultsAsync(TextWriter writer, MarkdownLinksVerifierConfiguration config, string? rootDirectory = null)
+        public static async Task<int> WriteResultsAsync(TextWriter writer, MarkdownLinksVerifierConfiguration? config, string? rootDirectory = null)
         {
             if (writer is null)
             {

--- a/actions/docs-verifier/src/MarkdownLinksVerifier/MarkdownFilesAnalyzer.cs
+++ b/actions/docs-verifier/src/MarkdownLinksVerifier/MarkdownFilesAnalyzer.cs
@@ -12,16 +12,12 @@ namespace MarkdownLinksVerifier
 {
     public static class MarkdownFilesAnalyzer
     {
-        public static async Task<int> WriteResultsAsync(TextWriter writer, MarkdownLinksVerifierConfiguration? config, string? rootDirectory = null)
+        public static async Task<int> WriteResultsAsync(
+            TextWriter writer, MarkdownLinksVerifierConfiguration? config, string? rootDirectory = null)
         {
             if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
-            }
-
-            if (config is null)
-            {
-                throw new ArgumentNullException(nameof(config));
             }
 
             var returnCode = 0;
@@ -41,7 +37,7 @@ namespace MarkdownLinksVerifier
                 {
                     LinkClassification classification = Classifier.Classify(link.Url);
                     ILinkValidator validator = LinkValidatorCreator.Create(classification, directory);
-                    if (!config.IsLinkExcluded(link.Url) && !validator.IsValid(link.Url, file))
+                    if (!IsLinkExcluded(config, link.Url) && !validator.IsValid(link.Url, file))
                     {
                         await writer.WriteLineAsync($"::error::In file '{file}': Invalid link: '{link.Url}' relative to '{directory}'.");
                         returnCode = 1;
@@ -50,6 +46,16 @@ namespace MarkdownLinksVerifier
             }
 
             return returnCode;
+
+            static bool IsLinkExcluded(MarkdownLinksVerifierConfiguration? config, string url)
+            {
+                if (config is null)
+                {
+                    return false;
+                }
+
+                return config.IsLinkExcluded(url);
+            }
         }
     }
 }

--- a/actions/docs-verifier/src/MarkdownLinksVerifier/MarkdownLinksVerifier.csproj
+++ b/actions/docs-verifier/src/MarkdownLinksVerifier/MarkdownLinksVerifier.csproj
@@ -12,4 +12,8 @@
     <InternalsVisibleTo Include="MarkdownLinksVerifier.UnitTests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\BuildVerifier.IO.Abstractions\BuildVerifier.IO.Abstractions.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/actions/docs-verifier/src/RedirectionVerifier/DocfxConfiguration.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/DocfxConfiguration.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace RedirectionVerifier
 {
-#pragma warning disable CA1812 // Avoid uninstantiated internal classes → JSON
     public sealed record DocfxConfiguration(
         [property: JsonPropertyName("build")] DocfxBuild? Build)
     {

--- a/actions/docs-verifier/src/RedirectionVerifier/DocfxConfiguration.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/DocfxConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.FileSystemGlobbing;
 namespace RedirectionVerifier
 {
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes → JSON
-    internal sealed record DocfxConfiguration(
+    public sealed record DocfxConfiguration(
         [property: JsonPropertyName("build")] DocfxBuild? Build)
     {
         private IEnumerable<Matcher>? _matchers;
@@ -67,11 +67,11 @@ namespace RedirectionVerifier
         }
     }
 
-    internal sealed record DocfxBuild(
-        [property: JsonPropertyName("content")] DocfxContent[]? Contents);
+    public sealed record DocfxBuild(
+        [property: JsonPropertyName("content")] IList<DocfxContent>? Contents);
 
-    internal sealed record DocfxContent(
+    public sealed record DocfxContent(
         [property: JsonPropertyName("src")] string? Source,
-        [property: JsonPropertyName("files")] string[]? Files,
-        [property: JsonPropertyName("exclude")] string[]? Excludes);
+        [property: JsonPropertyName("files")] IList<string>? Files,
+        [property: JsonPropertyName("exclude")] IList<string>? Excludes);
 }

--- a/actions/docs-verifier/src/RedirectionVerifier/DocfxConfigurationReader.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/DocfxConfigurationReader.cs
@@ -1,51 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
+using System.Threading.Tasks;
+using BuildVerifier.IO.Abstractions;
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace RedirectionVerifier
 {
-    public static class DocfxConfigurationReader
+    public class DocfxConfigurationReader
+        : BaseMappedConfigurationReader<DocfxConfiguration, IEnumerable<Matcher>>
     {
-        private static readonly JsonSerializerOptions s_options = new() { AllowTrailingCommas = true };
-        private static DocfxConfiguration? s_cachedDocfxConfiguration;
-        private static bool? s_fileExists;
-        private static Matcher s_matchAllMatcher = new Matcher().AddInclude("**");
-        private const string DocfxConfigurationFileName = "docfx.json";
+        private static readonly Matcher s_matchAllMatcher = new Matcher().AddInclude("**");
 
-        /// <summary>
-        /// Retrieves the path patterns excluded from publishing, which don't require a redirection when deleted/moved/renamed.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Failed to read <c>docfx.json</c>.</exception>
-        public static IEnumerable<Matcher> GetMatchers()
+        public override string ConfigurationFileName => "docfx.json";
+
+        public override async ValueTask<IEnumerable<Matcher>> MapConfigurationAsync()
         {
-            // Only check if the file exists one time.
-            if (s_fileExists is null)
-            {
-                s_fileExists = File.Exists(DocfxConfigurationFileName);
-            }
-
-            // If there are cached configuration values for "docfx", use 'em.
-            if (s_cachedDocfxConfiguration is not null)
-            {
-                return AdjustMatchers(s_cachedDocfxConfiguration.GetMatchers());
-            }
-
-            if (s_fileExists.Value)
-            {
-                string json = File.ReadAllText(DocfxConfigurationFileName);
-                DocfxConfiguration? configuration = JsonSerializer.Deserialize<DocfxConfiguration>(json, s_options);
-                if (configuration is null)
-                {
-                    throw new InvalidOperationException($"Failed to read '{DocfxConfigurationFileName}'.");
-                }
-
-                s_cachedDocfxConfiguration = configuration;
-            }
-
-            return AdjustMatchers(s_cachedDocfxConfiguration?.GetMatchers());
+            DocfxConfiguration? configuration = await ReadConfigurationAsync();
+            return AdjustMatchers(configuration?.GetMatchers());
         }
 
         private static IEnumerable<Matcher> AdjustMatchers(IEnumerable<Matcher>? matchers)

--- a/actions/docs-verifier/src/RedirectionVerifier/OpenPublishingRedirectionReader.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/OpenPublishingRedirectionReader.cs
@@ -1,42 +1,23 @@
-﻿using System;
-using System.Collections.Immutable;
-using System.IO;
-using System.Text.Json;
+﻿using System.Collections.Immutable;
+using System.Threading.Tasks;
+using BuildVerifier.IO.Abstractions;
 
 namespace RedirectionVerifier
 {
-    internal static class OpenPublishingRedirectionReader
+    public class OpenPublishingRedirectionReader
+        : BaseMappedConfigurationReader<OpenPublishingRedirections, ImmutableArray<Redirection>>
     {
-        private static readonly JsonSerializerOptions s_options = new() { AllowTrailingCommas = true };
-        private static OpenPublishingRedirections s_cachedOpenPublishingRedirections = null!;
-        private const string OpenPublishingRedirectionFileName = ".openpublishing.redirection.json";
+        public override string ConfigurationFileName => ".openpublishing.redirection.json";
 
-        /// <summary>
-        /// Retrieves the redirections from <c>.openpublishing.redirection.json</c>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Failed to read <c>.openpublishing.redirection.json</c>.</exception>
-        public static ImmutableArray<Redirection> GetRedirections()
+        public override async ValueTask<ImmutableArray<Redirection>> MapConfigurationAsync()
         {
-            // If there are cached redirections that were previously read and parsed, use 'em.
-            if (s_cachedOpenPublishingRedirections is { Redirections: { Length: > 0 } })
+            OpenPublishingRedirections? configuration = await ReadConfigurationAsync();
+            if (configuration is { Redirections: { Length: > 0 } })
             {
-                return s_cachedOpenPublishingRedirections.Redirections;
+                return configuration.Redirections;
             }
 
-            if (!File.Exists(OpenPublishingRedirectionFileName))
-            {
-                throw new InvalidOperationException($"File '{OpenPublishingRedirectionFileName}' was not found.");
-            }
-
-            string json = File.ReadAllText(OpenPublishingRedirectionFileName);
-            OpenPublishingRedirections? redirections = JsonSerializer.Deserialize<OpenPublishingRedirections>(json, s_options);
-            if (redirections is null)
-            {
-                throw new InvalidOperationException($"Failed to read '{OpenPublishingRedirectionFileName}'.");
-            }
-
-            s_cachedOpenPublishingRedirections = redirections;
-            return s_cachedOpenPublishingRedirections.Redirections;
+            return default;
         }
     }
 }

--- a/actions/docs-verifier/src/RedirectionVerifier/OpenPublishingRedirections.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/OpenPublishingRedirections.cs
@@ -3,9 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace RedirectionVerifier
 {
-#pragma warning disable CA1812 // Avoid uninstantiated internal classes → JSON
     public sealed class OpenPublishingRedirections
-#pragma warning restore CA1812 // Avoid uninstantiated internal classes
     {
         [JsonPropertyName("redirections")]
         public ImmutableArray<Redirection> Redirections { get; set; }

--- a/actions/docs-verifier/src/RedirectionVerifier/OpenPublishingRedirections.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/OpenPublishingRedirections.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace RedirectionVerifier
 {
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes → JSON
-    internal sealed class OpenPublishingRedirections
+    public sealed class OpenPublishingRedirections
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
     {
         [JsonPropertyName("redirections")]

--- a/actions/docs-verifier/src/RedirectionVerifier/Redirection.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/Redirection.cs
@@ -3,13 +3,15 @@
 namespace RedirectionVerifier
 {
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes → JSON
-    internal sealed class Redirection
+    public sealed class Redirection
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
     {
         [JsonPropertyName("source_path")]
         public string SourcePath { get; set; } = null!;
 
         [JsonPropertyName("redirect_url")]
+#pragma warning disable CA1056 // URI-like properties should not be strings → Could throw
         public string RedirectUrl { get; set; } = null!;
+#pragma warning restore CA1056 // URI-like properties should not be strings
     }
 }

--- a/actions/docs-verifier/src/RedirectionVerifier/Redirection.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/Redirection.cs
@@ -2,9 +2,7 @@
 
 namespace RedirectionVerifier
 {
-#pragma warning disable CA1812 // Avoid uninstantiated internal classes → JSON
     public sealed class Redirection
-#pragma warning restore CA1812 // Avoid uninstantiated internal classes
     {
         [JsonPropertyName("source_path")]
         public string SourcePath { get; set; } = null!;

--- a/actions/docs-verifier/src/RedirectionVerifier/RedirectionVerifier.csproj
+++ b/actions/docs-verifier/src/RedirectionVerifier/RedirectionVerifier.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\BuildVerifier.IO.Abstractions\BuildVerifier.IO.Abstractions.csproj" />
     <ProjectReference Include="..\GitHub\GitHub.csproj" />
   </ItemGroup>
 

--- a/actions/docs-verifier/src/RedirectionVerifier/RedirectionsVerifier.cs
+++ b/actions/docs-verifier/src/RedirectionVerifier/RedirectionsVerifier.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,14 +13,15 @@ namespace RedirectionVerifier
         /// Verifies a redirection for the given source path, and write logs (using GitHub-specific syntax) to a text writer.
         /// </summary>
         /// <returns>Returns <see langword="true"/> for a valid redirection; <see langword="false"/> otherwise.</returns>
-        public static async Task<bool> WriteResultsAsync(TextWriter writer, string sourcePath)
+        public static async Task<bool> WriteResultsAsync(
+            TextWriter writer, string sourcePath, ImmutableArray<Redirection> redirections)
         {
             if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            List<Redirection> foundRedirections = OpenPublishingRedirectionReader.GetRedirections().Where(redirection => redirection.SourcePath == sourcePath).ToList();
+            List<Redirection> foundRedirections = redirections.Where(redirection => redirection.SourcePath == sourcePath).ToList();
             if (foundRedirections.Count == 0)
             {
                 await writer.WriteLineAsync($"::error::No redirection is found for '{sourcePath}'.");

--- a/actions/docs-verifier/tests/MarkdownLinksVerifier/ConfigurationTests/ConfigurationReaderTests.cs
+++ b/actions/docs-verifier/tests/MarkdownLinksVerifier/ConfigurationTests/ConfigurationReaderTests.cs
@@ -44,7 +44,7 @@ namespace MarkdownLinksVerifier.UnitTests.ConfigurationTests
 
             MarkdownLinksVerifierConfiguration? configuration =
                 await new ConfigurationReader().ReadConfigurationAsync();
-            Assert.Equal(MarkdownLinksVerifierConfiguration.Empty, configuration);
+            Assert.Null(configuration);
         }
     }
 }

--- a/actions/docs-verifier/tests/MarkdownLinksVerifier/ConfigurationTests/ConfigurationReaderTests.cs
+++ b/actions/docs-verifier/tests/MarkdownLinksVerifier/ConfigurationTests/ConfigurationReaderTests.cs
@@ -8,7 +8,8 @@ namespace MarkdownLinksVerifier.UnitTests.ConfigurationTests
 {
     public class ConfigurationReaderTests
     {
-        private const string ConfigurationFileName = ConfigurationReader.ConfigurationFileName;
+        private static readonly string ConfigurationFileName =
+            new ConfigurationReader().ConfigurationFileName;
 
         [Theory]
         [InlineData(",")]
@@ -24,10 +25,11 @@ namespace MarkdownLinksVerifier.UnitTests.ConfigurationTests
     ""~/""{trailingComma}
   ]
 }}");
-                MarkdownLinksVerifierConfiguration configuration = await ConfigurationReader.GetConfigurationAsync();
-                Assert.Equal(2, configuration.ExcludeStartingWith.Length);
-                Assert.Contains(@"xref:", configuration.ExcludeStartingWith, StringComparer.Ordinal);
-                Assert.Contains("~/", configuration.ExcludeStartingWith, StringComparer.Ordinal);
+                MarkdownLinksVerifierConfiguration? configuration =
+                    await new ConfigurationReader().ReadConfigurationAsync();
+                Assert.Equal(2, configuration?.ExcludeStartingWith.Length);
+                Assert.Contains(@"xref:", configuration?.ExcludeStartingWith, StringComparer.Ordinal);
+                Assert.Contains("~/", configuration?.ExcludeStartingWith, StringComparer.Ordinal);
             }
             finally
             {
@@ -40,7 +42,8 @@ namespace MarkdownLinksVerifier.UnitTests.ConfigurationTests
         {
             Assert.False(File.Exists(ConfigurationFileName), $"Expected '{ConfigurationFileName}' to not exist.");
 
-            MarkdownLinksVerifierConfiguration configuration = await ConfigurationReader.GetConfigurationAsync();
+            MarkdownLinksVerifierConfiguration? configuration =
+                await new ConfigurationReader().ReadConfigurationAsync();
             Assert.Equal(MarkdownLinksVerifierConfiguration.Empty, configuration);
         }
     }

--- a/actions/docs-verifier/tests/MarkdownLinksVerifier/LinkValidatorTests/LocalLinkValidatorTests.cs
+++ b/actions/docs-verifier/tests/MarkdownLinksVerifier/LinkValidatorTests/LocalLinkValidatorTests.cs
@@ -9,7 +9,7 @@ namespace MarkdownLinksVerifier.UnitTests.LinkValidatorTests
     public class LocalLinkValidatorTests
     {
         private static async Task<int> WriteResultsAndGetExitCodeAsync(StringWriter writer, MarkdownLinksVerifierConfiguration? config = null)
-            => await MarkdownFilesAnalyzer.WriteResultsAsync(writer, config ?? MarkdownLinksVerifierConfiguration.Empty, $".{Path.DirectorySeparatorChar}WorkspaceTests");
+            => await MarkdownFilesAnalyzer.WriteResultsAsync(writer, config, $".{Path.DirectorySeparatorChar}WorkspaceTests");
 
         private static void Verify(string[] actual, (string File, string Link, string RelativeTo)[] expected)
         {


### PR DESCRIPTION
- Prefer instance-based classes over `static` classes
- Additional parameters on methods instead of relying on readers to read every time
- Two new `abstract` base classes:
  - `BaseConfigurationReader`: only requires the `ConfigurationFileName`, reads, and caches parsed config file
  - `BaseMappedConfigurationReader`: exposes custom mapping of the read config file
- General clean up and refactoring

Fixes #23

Attention: @Youssef1313 