### PR TITLE
Use `EndsWith` instead of `Equals` as the path can be included in the filename

### DIFF
--- a/actions/docs-verifier/src/ActionRunner/Program.cs
+++ b/actions/docs-verifier/src/ActionRunner/Program.cs
@@ -67,7 +67,8 @@ static bool IsRedirectableFile(
         ? file.PreviousFileName
         : (file.IsRemoved() ? file.FileName : null);
 
-    bool isDeletedToc = deletedFileName is not null && deletedFileName.Equals("toc.yml", StringComparison.OrdinalIgnoreCase);
+    bool isDeletedToc = deletedFileName is not null
+        && deletedFileName.EndsWith("toc.yml", StringComparison.OrdinalIgnoreCase);
 
     // A deleted toc.yml doesn't need redirection.
     // Also, don't require a redirection for file patterns specified as "exclude"s in docfx config file.


### PR DESCRIPTION
Instead of checking for full-string equality, use `EndsWith` as the filename can include the path.

Related to https://github.com/dotnet/docs/pull/25495#issuecomment-897627900

This should prevent false negatives:

```
Error: No redirection is found for 'docs/framework/resources/toc.yml'.
Error: No redirection is found for 'docs/standard/globalization-localization/toc.yml'.
```

/cc @Youssef1313